### PR TITLE
Fix conditional useRoutes invocation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,9 @@ import WidgetPage from "./components/widget/WidgetPage";
 import routes from "tempo-routes";
 
 function App() {
+  const tempoRoutes = useRoutes(routes);
+  const showTempo = import.meta.env.VITE_TEMPO === "true";
+
   return (
     <Suspense fallback={<p>Loading...</p>}>
       <>
@@ -18,7 +21,7 @@ function App() {
           <Route path="/settings" element={<SettingsPage />} />
           <Route path="/widget" element={<WidgetPage />} />
         </Routes>
-        {import.meta.env.VITE_TEMPO === "true" && useRoutes(routes)}
+        {showTempo && tempoRoutes}
       </>
     </Suspense>
   );


### PR DESCRIPTION
## Summary
- avoid conditionally invoking `useRoutes` in App to comply with hook rules

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_689953d5f40c832388388e00809025a6